### PR TITLE
Withdrew "Nouveau" from "Confirmez votre nouveau mot de passe"

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,6 +31,8 @@ fr:
         scope_type: Type de zone d'application
       user:
         nickname: Votre pseudonyme
+        password: Votre mot de passe
+        password_confirmation: Confirmez votre mot de passe
   activerecord:
     attributes:
       decidim/participatory_process:


### PR DESCRIPTION
Je trouvais que "Nouveau" sortait un peu de nulle part. T'en penses quoi ?