### PR TITLE
Require fog in carrierwave

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'carrierwave/storage/fog'
+
 # Default CarrierWave setup.
 #
 CarrierWave.configure do |config|


### PR DESCRIPTION
Fix asset precompilation on heroku -> should be tested outside of Heroku?