### PR TITLE
Feature add orejime cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "decidim", git: "https://github.com/decidim/decidim.git", branch: "release/0
 gem "decidim-navbar_links", git: "https://github.com/OpenSourcePolitics/decidim-module-navbar_links.git", branch: "0.22-stable"
 # gem "decidim-navigation_maps", git: "https://github.com/Platoniq/decidim-module-navigation_maps"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.dev"
+gem "decidim-cookies", git: "https://github.com/OpenSourcePolitics/decidim-module_cookies.git", branch: "release/0.22-stable"
 
 gem "bootsnap", "~> 1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,14 @@ GIT
       decidim-core
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module_cookies.git
+  revision: b3ea1a0a5cdd5852617f1967b07216d8cd970621
+  branch: release/0.22-stable
+  specs:
+    decidim-cookies (0.22.0)
+      decidim-core (= 0.22.0)
+
+GIT
   remote: https://github.com/decidim/decidim.git
   revision: d80d6cb6d1f59963b0a452e418f4a4788abaf1a9
   branch: release/0.22-stable
@@ -836,6 +844,7 @@ DEPENDENCIES
   byebug (~> 11.0)
   dalli
   decidim!
+  decidim-cookies!
   decidim-dev!
   decidim-navbar_links!
   decidim-term_customizer!

--- a/app/views/layouts/decidim/_main_footer.html.erb
+++ b/app/views/layouts/decidim/_main_footer.html.erb
@@ -20,6 +20,9 @@
         <% end %>
       <% end %>
       <li><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
+      <% if cookies_accepted? %>
+        <li><%= link_to t("layouts.decidim.footer.revoke_cookies"), "#", id: "reset-button" %></li>
+      <% end %>
     </ul>
     <%= render partial: "layouts/decidim/social_media_links" %>
   </div>

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -10,7 +10,7 @@ if respond_to?(:current_component) && current_component && can_be_managed?(curre
 end
 %>
 
-<div class="off-canvas-wrapper">
+<div class="off-canvas-wrapper" id="app">
   <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
     <div class="off-canvas position-right hide-for-large" data-position="right"
          id="offCanvas" data-off-canvas>

--- a/config/initializers/cookies.rb
+++ b/config/initializers/cookies.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Rails.application.config.cookies = [
+  {
+    name: "matomo",
+    title: "Matomo",
+    cookies: %w(matomo_session pk_id pk_ses _pk_ref _pk_cvar),
+    purposes: %w(tracking analytics)
+  }
+]


### PR DESCRIPTION
Add Decidim cookies module using Orejime on `release/0.22-stable` version.

## Subtasks
- [x] Add `matomo` as default cookies in banner