### PR TITLE
Update orejime on bosa-0.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "decidim", git: "https://github.com/OpenSourcePolitics/decidim.git", branch:
 # gem "decidim-consultations", path: "../decidim"
 # gem "decidim-initiatives", path: "../decidim"
 
-gem "decidim-cookies", git: "https://github.com/OpenSourcePolitics/decidim-module_cookies.git", branch: "feature/refactor_osp-0.18"
+gem "decidim-cookies", git: "https://github.com/OpenSourcePolitics/decidim-module_cookies.git", branch: "osp/orejime-0.18"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.18-stable"
 gem "decidim-polis", git: "https://github.com/OpenSourcePolitics/decidim-polis.git", branch: "0.18-stable"
 gem "decidim-socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-socio_demographic_authorization_handler"

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "decidim", git: "https://github.com/OpenSourcePolitics/decidim.git", branch:
 # gem "decidim-consultations", path: "../decidim"
 # gem "decidim-initiatives", path: "../decidim"
 
+gem "decidim-cookies", git: "https://github.com/OpenSourcePolitics/decidim-module_cookies.git", branch: "feature/refactor_osp-0.18"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.18-stable"
-gem "decidim-cookies", git: "https://github.com/OpenSourcePolitics/decidim-module_cookies.git", branch: "osp/orejime-0.18"
 gem "decidim-polis", git: "https://github.com/OpenSourcePolitics/decidim-polis.git", branch: "0.18-stable"
 gem "decidim-socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-socio_demographic_authorization_handler"
 # gem "decidim-socio_demographic_authorization_handler",  path: "../decidim-module-socio_demographic_authorization_handler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_cookies.git
-  revision: 12b7b3806f4a5aeee8e1b09b38abffd2ecd4cd5e
-  branch: osp/orejime-0.18
+  revision: 0d2367376ed0783e9a06bbab1f1e42d4004b90ea
+  branch: feature/refactor_osp-0.18
   specs:
     decidim-cookies (0.18.0)
       decidim-core (= 0.18.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_cookies.git
-  revision: 0d2367376ed0783e9a06bbab1f1e42d4004b90ea
-  branch: feature/refactor_osp-0.18
+  revision: a1654c1e75e69f0968306ae6ed65c74eec2e70d0
+  branch: osp/orejime-0.18
   specs:
     decidim-cookies (0.18.0)
       decidim-core (= 0.18.0)

--- a/config/initializers/cookies.rb
+++ b/config/initializers/cookies.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Example of how to define new cookie in banner
+#
+Rails.application.config.cookies = [
+  {
+      name: "jsessionid",
+      title: "JSESSIONID",
+      cookies: %w(JSESSIONID),
+      purposes: %w(session tracking analytics)
+  },
+  {
+    name: "matomo",
+    title: "Matomo",
+    cookies: %w(matomo_session pk_id pk_ses _pk_ref _pk_cvar),
+    purposes: %w(tracking analytics)
+  }
+]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,12 @@ en:
           age: Age
           gender: Gender
           scope_id: Scope
+    components:
+      cookies:
+        jsessionid:
+          description: The JSESSIONID cookie is used to store a session identifier so that New Relic can monitor session counts for an application
+        matomo:
+          description: Allows to track to improve user experience
     proposals:
       proposals:
         proposals:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,6 +19,11 @@ fr:
         name: Formulaire de vérification d'identité
       osp_authorization_workflow:
         name: Procédure d'autorisation
+    components:
+      jsessionid:
+        description: Le cookie JSESSIONID permet de sauvegarder un identifiant de session. Celui-ci est nécessaire pour permettre à New Relic de monitorer la session
+      matomo:
+        description: Permet de récolter des informations afin d'améliorer l'expérience
     devise:
       omniauth_callbacks:
         saml: e-ID ou via itsme


### PR DESCRIPTION
Update Orejime version on `alt/bosa-0.18`.

📖 Tasks:
- [x] Add `JSESSIONID` et `Matomo` to cookies banner
- [ ] Add missing translation

 🔴 Resume 
Cookies enabled : 
- [x] `decidim-cc` required
- [x] `decidim_session` required
- [x] `JSESSIONID` optional
- [x] `Matomo` optional
