### PR TITLE
Fix cookie overflow collaborative draft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "omniauth-saml", "~> 1.10.0"
 gem "sprockets", "~> 3.7"
 
 gem "dotenv-rails"
+gem "activerecord-session_store"
+
 
 group :development, :test do
   gem "byebug", "~> 10.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,12 @@ GEM
       activemodel (= 5.2.4)
       activesupport (= 5.2.4)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4)
       actionpack (= 5.2.4)
       activerecord (= 5.2.4)
@@ -829,6 +835,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.3)
   byebug (~> 10.0)
   dalli

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_cookies.git
-  revision: 12b7b3806f4a5aeee8e1b09b38abffd2ecd4cd5e
+  revision: a1654c1e75e69f0968306ae6ed65c74eec2e70d0
   branch: osp/orejime-0.18
   specs:
     decidim-cookies (0.18.0)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, :key => '_decidim_session', expire_after: Decidim.config.expire_session_after

--- a/db/migrate/20200908112637_add_sessions_table.rb
+++ b/db/migrate/20200908112637_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_153643) do
+ActiveRecord::Schema.define(version: 2020_09_08_112637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1336,6 +1336,15 @@ ActiveRecord::Schema.define(version: 2020_01_28_153643) do
     t.boolean "confidential", default: true, null: false
     t.index ["decidim_organization_id"], name: "index_oauth_applications_on_decidim_organization_id"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
## What ? Why ? 
When user tries to save a collaborative draft with a body heavier than 4kb a CookieOverflow error is raised. 

Furthermore, bump the decidim cookies module version to add `decidim-session` to the banner.