### PR TITLE
Fix attachments_url undefined method in proposals exporter

### DIFF
--- a/lib/extends/decidim/proposal_serializer_extends.rb
+++ b/lib/extends/decidim/proposal_serializer_extends.rb
@@ -50,6 +50,9 @@ module ProposalSerializerExtends
     authors
   end
 
+  def attachments_url
+    proposal.attachments.map { |attachment| proposal.organization.host + attachment.url }
+  end
 end
 
 Decidim::Proposals::ProposalSerializer.class_eval do


### PR DESCRIPTION
#### What ? Why ?

Proposals exporter fails because of missing method `attachments_url`. Backport previously added method in `0.18-merge`

#### Related to : 
- PR : https://github.com/OpenSourcePolitics/decidim/pull/602